### PR TITLE
NO-REF: Pass data for label either way if available in NYPL core

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -55,18 +55,24 @@ end
 def fetch_locations_and_respond(params)
   req_codes = params['location_codes'].split(",")
   records = req_codes.map do |req_code|
+    data = []
+    core_data = $nypl_core.check_sierra_location(req_code) || {}
+    label = core_data['label'] || nil
+
+    $locations.select {|k,v| k.match? req_code}.each {|k,v|
+      v[:label] = label
+      data << v
+    }
+
+    data << { code: req_code, label: label, url: nil } if data.length == 0
+
     [
       req_code,
-      $locations.select {|k,v| k.match? req_code}.map {|k,v|
-        core_data = $nypl_core.check_sierra_location(req_code) || {}
-        v[:label] = core_data['label'] ? core_data['label'] : nil
-
-        v
-      }
+      data
     ]
   end.to_h
-rescue StandardError
-    $logger.info 'Received error in fetch_locations_and_respond'
+rescue StandardError => e
+    $logger.warn "Received error in fetch_locations_and_respond. Message: #{e.message}"
     create_response(500, 'Failed to fetch locations by code')
 else
     create_response(200, records)

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -154,4 +154,27 @@ describe 'fetch_locations_and_respond' do
       }
     )
   end
+
+  it 'if not in locations S3, should still return label from NYPL core, if available' do
+    expect(
+      fetch_locations_and_respond({ 'location_codes' => 'sa' })
+    ).to eq(
+      {
+        :body => {
+          "sa" => [
+            {
+              :code => "sa",
+              :label => "St. A",
+              :url => nil
+            }
+          ]
+        }.to_json,
+        :headers => {
+          :"Content-type" => "application/json"
+        },
+        :isBase64Encoded => false,
+        :statusCode => 200
+      }
+    )
+  end
 end

--- a/spec/fixtures/by_sierra_location.json
+++ b/spec/fixtures/by_sierra_location.json
@@ -10,5 +10,17 @@
     "sierraDeliveryLocations": [],
     "requestable": false,
     "deliveryLocationTypes": []
+  },
+  "sa": {
+    "code": "sa",
+    "label": "St. A",
+    "locationsApiSlug": null,
+    "collectionTypes": [
+      "Branch"
+    ],
+    "recapLocation": null,
+    "sierraDeliveryLocations": [],
+    "requestable": false,
+    "deliveryLocationTypes": []
   }
 }


### PR DESCRIPTION
"sn" is missing in the locations s3, but exists in NYPL core. This PR enables passing that core data and tests this case.